### PR TITLE
allow dependency to also resolve in leiningen2

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,3 +1,3 @@
 (defproject mathemagician "0.0.1"
   :description "Automatically generate Clojure function proxies for java.lang.Math static methods."
-  :dependencies [[clojure "1.4.0"]])
+  :dependencies [[org.clojure/clojure "1.4.0"]])


### PR DESCRIPTION
When I tried to run tests with leiningen2 I got:

``` sh
$ lein test
Could not find artifact clojure:clojure:pom:1.4.0 in central (http://repo1.maven.org/maven2)
Could not find artifact clojure:clojure:pom:1.4.0 in clojars (https://clojars.org/repo/)
Could not find artifact clojure:clojure:jar:1.4.0 in central (http://repo1.maven.org/maven2)
Could not find artifact clojure:clojure:jar:1.4.0 in clojars (https://clojars.org/repo/)
Could not find artifact clojure:clojure:jar:1.4.0 in central (http://repo1.maven.org/maven2)
Check :dependencies and :repositories for typos.
It's possible the specified jar is not in any repository.
If so, see "Free-floating Jars" under http://j.mp/repeatability
```

This fix copies how other projects do it i.e. [noir](https://github.com/ibdknox/noir/blob/master/project.clj)
